### PR TITLE
fix: fix defaultCode.C

### DIFF
--- a/code.go
+++ b/code.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	unknownCoder defaultCoder = defaultCoder{1, http.StatusInternalServerError, "An internal server error occurred", "http://github.com/marmotedu/errors/README.md"}
+	unknownCoder defaultCoder = defaultCoder{0, http.StatusInternalServerError, "An internal server error occurred", "http://github.com/marmotedu/errors/README.md"}
 )
 
 // Coder defines an interface for an error code detail information.

--- a/errors_test.go
+++ b/errors_test.go
@@ -310,8 +310,8 @@ func TestParseCoder(t *testing.T) {
 		wantCode      int
 		wantReference string
 	}{
-		{fmt.Errorf("yes error"), 500, "An internal server error occurred", 1, "http://github.com/marmotedu/errors/README.md"},
-		{WithCode(unknownCoder.Code(), "internal error message"), 500, "An internal server error occurred", 1, "http://github.com/marmotedu/errors/README.md"},
+		{fmt.Errorf("yes error"), 500, "An internal server error occurred", 0, "http://github.com/marmotedu/errors/README.md"},
+		{WithCode(unknownCoder.Code(), "internal error message"), 500, "An internal server error occurred", 0, "http://github.com/marmotedu/errors/README.md"},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
From Register/MustRegister method, we can known defaultCode.C should be 0, so I think maybe it should keep the same rule.